### PR TITLE
Fixes for the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM maven:3.6-jdk-8
-MAINTAINER Nathan Walker <nathan@rylath.net>, Sean Óg Crudden <og.crudden@gmail.com>
+LABEL org.opencontainers.image.authors="Nathan Walker <nathan@rylath.net>, Sean Óg Crudden <og.crudden@gmail.com>"
 
 ARG AGENCYID="1"
 ARG AGENCYNAME="GOHART"
@@ -40,7 +40,8 @@ EXPOSE 8080
 
 # Install json parser so we can read API key for CreateAPIKey output
 
-RUN wget http://stedolan.github.io/jq/download/linux64/jq
+RUN wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+RUN mv ./jq-linux-amd64 ./jq
 
 RUN chmod +x ./jq
 
@@ -105,4 +106,4 @@ ADD config/test/* /usr/local/transitclock/config/test/
 
 EXPOSE 8080
 
-CMD ["/start_transitclock.sh"]
+CMD ["./bin/start_transitclock.sh"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Things to make transitime go:
 
 - Ubuntu
 - sudo apt-get install git
-- git clone https://github.com/scrudden/transitime-docker.git
+- git clone https://github.com/TheTransitClock/transitclockDocker.git
 - curl -sSL https://get.docker.com/ | sh  (i.e. install docker)
 - Configure agency details in the go.sh script. Here you set the agency name, agency id** (as in GTFS feed), GTFS feed location and GTFS-realtime vehicle location url.
 - ./go.sh


### PR DESCRIPTION
I just gave the transitime-docker container setup a try and found some issues. This PR includes some fixes to get it up and running:
- Update Link in README.md
- Update jq Link in Dockerfile
- Replace Label by Maintainer tag to fix deprecation warning
- fix CMD command